### PR TITLE
GC_FR-18 collection のcase変換関数のロジックを修正する。

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -1,15 +1,17 @@
 import _ from 'lodash';
 import Case from 'case';
-import {camelizeKeys} from 'ramda-extension';
 
 export const toCamelKeys = collection => {
   if (_.isString(collection)) {
-    return __changeCases(collection, 'camel');
-  } else {
-    return camelizeKeys(collection);
+    return _.camelCase(collection);
   }
+  return __changeCases(collection, 'camel');
 };
+
 export const toSnakeKeys = collection => {
+  if (_.isString(collection)) {
+    return _.snakeCase(collection);
+  }
   return __changeCases(collection, 'snake');
 };
 
@@ -19,9 +21,8 @@ const __changeCases = (collection, caseName) => {
   } else if (_.isPlainObject(collection)) {
     let obj = {...collection};
     obj = _.mapKeys(obj, (v, k) => Case[caseName](k));
+    obj = _.mapValues(obj, v => __changeCases(v, caseName));
     return obj;
-  } else if (_.isString(collection)) {
-    return Case[caseName](collection);
   }
 
   // ArrayまたはObject、Stringで無ければそのまま

--- a/src/collection.test.js
+++ b/src/collection.test.js
@@ -1,35 +1,8 @@
 import * as collection from './collection';
 
-// 配列内のオブジェクトのキーのスネークをキャメルに変換する
-test('toCamelKeys (case Array)', () => {
-  const snakeCase = [
-    {
-      gem_id: 1,
-      gem_name: 'ダイヤモンド',
-      gem_price: 100,
-    },
-    {
-      gem_id: 2,
-      gem_name: 'ターコイズ',
-      gem_price: 200,
-    },
-  ];
-
-  const expectedData = [
-    {
-      gemId: 1,
-      gemName: 'ダイヤモンド',
-      gemPrice: 100,
-    },
-    {
-      gemId: 2,
-      gemName: 'ターコイズ',
-      gemPrice: 200,
-    },
-  ];
-
-  expect(expectedData).toEqual(collection.toCamelKeys(snakeCase));
-});
+// -----------------------------------------------------------------------------
+// toCamelKeys
+// -----------------------------------------------------------------------------
 
 // オブジェクト内のキーのスネークをキャメルに変換する
 test('toCamelKeys (case Object)', () => {
@@ -48,8 +21,42 @@ test('toCamelKeys (case Object)', () => {
   expect(expectedData).toEqual(collection.toCamelKeys(snakeCase));
 });
 
+// オブジェクト内のオブジェクトのキーのスネークをキャメルに変換する
+test('toCamelKeys (case Object in Object)', () => {
+  const snakeCase = {
+    gem_data: {
+      gem_id: 1,
+      gem_name: 'ダイヤモンド',
+      gem_price: 100,
+    },
+  };
+
+  const expectedData = {
+    gemData: {
+      gemId: 1,
+      gemName: 'ダイヤモンド',
+      gemPrice: 100,
+    },
+  };
+
+  expect(expectedData).toEqual(collection.toCamelKeys(snakeCase));
+});
+
+// オブジェクト内のキーのみをキャメルに変換する
+test('toCamelKeys (case Object in Array)', () => {
+  const snakeCase = {
+    gem_data: ['gem_id', 1, 'gem_name', 'ダイヤモンド', 'gem_price', 100],
+  };
+
+  const expectedData = {
+    gemData: ['gem_id', 1, 'gem_name', 'ダイヤモンド', 'gem_price', 100],
+  };
+
+  expect(expectedData).toEqual(collection.toCamelKeys(snakeCase));
+});
+
 // オブジェクト内のキーのスネークをキャメルに変換する
-test('toCamelKeys (case Array in Object in Object)', () => {
+test('toCamelKeys (case Object in Array in Object)', () => {
   const snakeCase = {
     gem_one: [
       {
@@ -103,6 +110,37 @@ test('toCamelKeys (case Array in Object in Object)', () => {
       },
     ],
   };
+
+  expect(expectedData).toEqual(collection.toCamelKeys(snakeCase));
+});
+
+// 配列内のオブジェクトのキーのスネークをキャメルに変換する
+test('toCamelKeys (case Array in Object)', () => {
+  const snakeCase = [
+    {
+      gem_id: 1,
+      gem_name: 'ダイヤモンド',
+      gem_price: 100,
+    },
+    {
+      gem_id: 2,
+      gem_name: 'ターコイズ',
+      gem_price: 200,
+    },
+  ];
+
+  const expectedData = [
+    {
+      gemId: 1,
+      gemName: 'ダイヤモンド',
+      gemPrice: 100,
+    },
+    {
+      gemId: 2,
+      gemName: 'ターコイズ',
+      gemPrice: 200,
+    },
+  ];
 
   expect(expectedData).toEqual(collection.toCamelKeys(snakeCase));
 });


### PR DESCRIPTION
### 課題URL

* https://gemcook.backlog.jp/view/GC_FR-18

### 追加・修正が確認できる手順

* Objectのvalueが文字列だった場合、valueがcase変換されていた

### アサイニーが確認した項目

* 実際に動きを確認した項目を記載

### 技術的変更点

* 文字列のcase変換を再帰的に処理しないようにした

### レビュワーに対する注意点

* 課題詳細の記述通りのテストケースでテストを修正しました
* テストはオールグリーンです
