### PR TITLE
GC_FR-72 @gemcook/utils の build 結果に eval 構文が吐き出されないようにする。

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "test": "jest"
   },
   "dependencies": {
+    "base-64": "^0.1.0",
     "case": "^1.6.1",
     "date-fns": "^2.0.0-alpha.24",
-    "js-base64": "^2.4.3",
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.11",
     "moment": "^2.23.0",

--- a/src/base64.js
+++ b/src/base64.js
@@ -1,5 +1,5 @@
-import {Base64} from 'js-base64';
+import Base64 from 'base-64';
 
-export const decode = (str: string) => {
+export const decode = str => {
   return Base64.decode(str);
 };

--- a/src/base64.test.js
+++ b/src/base64.test.js
@@ -1,0 +1,12 @@
+import * as base64 from './base64';
+
+// -----------------------------------------------------------------------------
+// toCamelKeys
+// -----------------------------------------------------------------------------
+
+// オブジェクト内のキーのスネークをキャメルに変換する
+test('Base 64 Decode', () => {
+  const expectedData = "abc123!?$*&()'-=@~";
+
+  expect(expectedData).toEqual(base64.decode('YWJjMTIzIT8kKiYoKSctPUB+'));
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1403,6 +1403,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base-64@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
+  integrity sha1-eAqZyE59YAJgNhURxId2E78k9rs=
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -3520,11 +3525,6 @@ jest@^24.5.0:
   dependencies:
     import-local "^2.0.0"
     jest-cli "^24.5.0"
-
-js-base64@^2.4.3:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.1.tgz#1efa39ef2c5f7980bb1784ade4a8af2de3291121"
-  integrity sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==
 
 js-levenshtein@^1.1.3:
   version "1.1.6"


### PR DESCRIPTION
### 課題URL


* https://gemcook.backlog.jp/view/GC_FR-72


### 追加・修正が確認できる手順


1. `base64.encode()` を使う


### アサイニーが確認した項目


- rollup の eval warning が発生しなかったこと
- base64のライブラリを変更しても動作がかわらないこと
- 他プロジェクトで試して使っても問題が無かったこと


### 技術的変更点


- `js-base64` -> `base-64` にライブラリを変更しました
- base64 の エンコードする関数のテストを追加しました


### レビュワーに対する注意点


なし


### 課題とは直接関係がないが修正した項目


- テストファイルの追加


### 今回保留した項目


- rollup 周りはTypeScript化するタイミングで最新にします


### リリース・マージに対する注意点


なし


### その他


なし



